### PR TITLE
Fix UnicodeDecodeError in ebxtoasset.py

### DIFF
--- a/frostbite3/ebx.py
+++ b/frostbite3/ebx.py
@@ -341,7 +341,7 @@ class Dbx:
                     a=f.read(1)
                     if a==b"\x00": break
                     data+=a
-                field.value=data.decode("utf-8")
+                field.value=data.decode("ISO-8859-1")
                 f.seek(startPos+4)
 
                 if self.isPrimaryInstance and fieldDesc.name=="Name" and self.trueFilename=="":


### PR DESCRIPTION
System used: Windows 10 Enterprise ver. 19042.867 (x64), Python 3.9.2 (x64)
Attempting to run ebxtoasset.py on Battlefield 1 assets results in this error:

````
Traceback (most recent call last):

  File "D:\Frostbite-Scripts-master\frostbite3\ebxtoasset.py", line 36, in <module>
    dbx=ebx.Dbx(os.path.join(dir0,fname),ebxFolder)
  File "D:\Frostbite-Scripts-master\frostbite3\ebx.py", line 271, in __init__
    inst=self.readComplex(instanceRepeater.complexIndex,f,True)
  File "D:\Frostbite-Scripts-master\frostbite3\ebx.py", line 298, in readComplex
    cmplx.fields.append(self.readField(fieldIndex,f))
  File "D:\Frostbite-Scripts-master\frostbite3\ebx.py", line 344, in readField
    field.value=data.decode("utf-8")
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xda in position 1: invalid continuation byte
````
Using ISO-8859-1 instead of utf-8 _seems_ to work with both ebxtoasset.py and ebxtottext.py but I only tested the change on Battlefield 1 assets.